### PR TITLE
Fixed a small bug in scoreCal

### DIFF
--- a/Game/assets/js/ScoreCalculator2.js
+++ b/Game/assets/js/ScoreCalculator2.js
@@ -306,5 +306,6 @@ function convertHMS(value) {
     if (hours   < 10) {hours   = "0"+hours;}
     if (minutes < 10) {minutes = "0"+minutes;}
     if (seconds < 10) {seconds = "0"+seconds;}
+    if (subseconds  < 100) {subseconds   = "0"+subseconds;}
     return minutes+':'+seconds+':'+subseconds; // Return is HH : MM : SS
 }


### PR DESCRIPTION
Previously, it will display 01:46:13, which is unclear. Now, it will display 01:46:013 if sub-seconds is < 100.